### PR TITLE
修复JavaSDK里无法请求信道服务器的BUG，又是字符串使用=惹的祸

### DIFF
--- a/com.qcloud.weapp.sdk/src/com/qcloud/weapp/tunnel/TunnelService.java
+++ b/com.qcloud.weapp.sdk/src/com/qcloud/weapp/tunnel/TunnelService.java
@@ -70,10 +70,10 @@ public class TunnelService {
 	 * @param options 指定信道服务的配置
 	 */
 	public void handle(TunnelHandler handler, TunnelHandleOptions options) throws ConfigurationException {
-		if (request.getMethod().toUpperCase() == "GET") {
+		if (request.getMethod().toUpperCase().equals("GET")) {
 			handleGet(handler, options);
 		}
-		if (request.getMethod().toUpperCase() == "POST") {
+		if (request.getMethod().toUpperCase().equals("POST")) {
 			handlePost(handler, options);
 		}
 	}


### PR DESCRIPTION
字符串的比较应当使用equals而非=，腾讯的同学应当不是这个水平啊。